### PR TITLE
chore: use switch for bedroom mirror display

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -41,24 +41,15 @@ google_assistant:
   service_account: !include service-account.json
   report_state: true
 
-rest:
-  - resource: https://mm-controller.proxy.lan.qidux.com/display-state
-    binary_sensor:
-      - name: Bedroom Mirror Display
-        unique_id: bedroom_mirror_display
-        value_template: "{{ value_json.on }}"
+switch:
+  - name: Bedroom Mirror Display
+    platform: rest
+    resource: https://mm-controller.proxy.lan.qidux.com/display-state
+    body_on: '{"on": true}'
+    body_off: '{"on": false}'
+    is_on_template: "{{ value_json.on }}"
 
 rest_command:
-  magic_mirror_on:
-    url: https://mm-controller.proxy.lan.qidux.com/display-state
-    method: put
-    content_type: application/json
-    payload: '{"on": true}'
-  magic_mirror_off:
-    url: https://mm-controller.proxy.lan.qidux.com/display-state
-    method: put
-    content_type: application/json
-    payload: '{"on": false}'
   magic_mirror_refresh:
     url: https://mm-controller.proxy.lan.qidux.com/refresh
     method: post


### PR DESCRIPTION
Using a switch gets us the current state and on/off toggle for free
instead of using custom binary sensors and on/off commands.
